### PR TITLE
Reorganize output config parameters (close #54)

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ And start generating events in your `my-events` directory, in configuration file
 ```
 "output": {
   "file": {
-    "uri": "file:/path/to/my-events"
+    "path": "file:/path/to/my-events"
   }
 }
 ```
@@ -30,7 +30,7 @@ Alternatively you can write events directly to a S3 bucket:
 ```
 "output": {
   "file": {
-    "uri": "s3://my-bucket/my-events"
+    "path": "s3://my-bucket/my-events"
   }
 }
 ```
@@ -40,7 +40,8 @@ Alternatively you can write events directly to a S3 bucket:
 ```
 "output": {
   "kinesis": {
-    "uri": "kinesis://my-kinesis-stream"
+    "streamName": "my-stream",
+    "region": "eu-central-1"
   }
 }
 ```
@@ -51,8 +52,8 @@ Alternatively you can write events directly to a S3 bucket:
 
 ```
 "output": {
-  "kinesis": {
-    "uri": "pubsub://projects/my-project/topics/my-topic"
+  "pubsub": {
+    "subscription": "projects/my-project/topics/my-topic"
   }
 }
 ```

--- a/sinks/src/main/scala/com.snowplowanalytics.snowplow.eventgen/Config.scala
+++ b/sinks/src/main/scala/com.snowplowanalytics.snowplow.eventgen/Config.scala
@@ -70,9 +70,9 @@ object Config {
   )
 
   sealed trait Target
-  case class Kinesis(uri: URI, region: Option[String]) extends Target
-  case class File(uri: URI) extends Target
-  case class PubSub(uri: URI) extends Target
+  case class Kinesis(streamName: String, region: Option[String]) extends Target
+  case class File(path: URI) extends Target
+  case class PubSub(subscription: String) extends Target
   case class Kafka(brokers: String, topic: String, producerConf: Map[String, String] = Map.empty) extends Target
 
   val configOpt   = Opts.option[Path]("config", "Path to the configuration HOCON").orNone


### PR DESCRIPTION
Previously config parameters relied upon URIs (some of them artificial) for most of the sinks.
Parameter names and formats now follow regular values not URIs unless required (eg. File/S3 paths).