### PR TITLE
Feature/http sink

### DIFF
--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -16,6 +16,6 @@ jobs:
         uses: snyk/actions/scala@master
         with:
           command: monitor
-          args: --project-name=snowplow-event-generator
+          args: --project-name=snowplow-event-generator --prune-repeated-subdependencies
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -80,6 +80,15 @@ Alternatively you can write events directly to a S3 bucket:
 }
 ```
 
+...or a Snowplow collector:
+
+```
+"output": {
+  "type": "Http"
+  "endpoint": "https://my.collector.endpoint.com"
+}
+```
+
 Then run:
 ```bash
 ./snowplow-event-generator --config my-config.hocon
@@ -186,7 +195,31 @@ Aside from "output" configuration, all fields in the configuration file are opti
 
       // Only used for "Fixed" timestamps.  Change this to generate more recent or more historic events.
       "at": "2022-02-01T01:01:01z"
-    },
+    }
+
+    // Set weights for the distributions of event types. 
+    // Setting a fequency to 0 results in that event type not being produced at all
+    // Setting equal values results in an even distribution of event types.
+    "eventFrequencies": {
+      "struct": 1
+      "unstruct": 1
+      "pageView": 1
+      "pagePing": 1
+      "unstructEventFrequencies": {
+        "changeForm": 1
+        "funnelInteraction": 1
+        "linkClick": 1
+      }
+    }
+
+    // HTTP output only - set weights for the distributions of request methods.
+    // Setting a fequency to 0 results in that method not being produced at all
+    // Note that head requests are currently not implemented and will result in an exception.
+    "methodFrequencies": {
+        "post": 1
+        "get": 1
+        "head": 0
+    }
 
     // Required: Storage to sink generated events into
     // Currently only a single output at a time is supported
@@ -216,6 +249,10 @@ Aside from "output" configuration, all fields in the configuration file are opti
       // "type": "PubSub"
       // Required: PubSub stream URI
       // "uri": "pubsub://projects/my-project/topics/my-topic"
+
+      // "type": "Http"
+      // Required: Snowplow collector endpoint, including protocol
+      // "endpoint": "https://my.collector.endpoint.com"
     }
 }
 ```

--- a/build.sbt
+++ b/build.sbt
@@ -70,8 +70,14 @@ lazy val sinks = project
       Dependencies.Libraries.kcl,
       Dependencies.Libraries.fs2Pubsub,
       Dependencies.Libraries.fs2Kafka,
-      Dependencies.Libraries.awsRegions
-    )
+      Dependencies.Libraries.awsRegions,
+      "org.http4s" %% "http4s-ember-client" % "0.23.15",
+      "org.http4s" %% "http4s-circe" % "0.23.15"
+      // TODO move this
+    ),
+    //libraryDependencies += "org.typelevel" %% "cats-effect" % "3.4.6",
+    // libraryDependencies += "org.http4s"    %% "http4s-ember-client" % "0.23.15",
+    // libraryDependencies += "org.http4s" %% "http4s-circe" % "0.23.15"
   )
   .dependsOn(core)
 

--- a/core/src/main/scala/com/snowplowanalytics/snowplow/eventgen/tracker/HttpRequest.scala
+++ b/core/src/main/scala/com/snowplowanalytics/snowplow/eventgen/tracker/HttpRequest.scala
@@ -32,12 +32,24 @@ object HttpRequest {
     val path: Api
   }
 
+  case class MethodFrequencies(
+  get: Int,
+  post: Int,
+  head: Int
+)
+
   object Method {
     final case class Post(path: Api) extends Method
     final case class Get(path: Api) extends Method
     final case class Head(path: Api) extends Method
 
-    def gen: Gen[Method] = Gen.oneOf(genPost, genGet, genHead)
+    def gen(freq: MethodFrequencies): Gen[Method] = {
+      Gen.frequency(
+        (freq.post, genPost), 
+        (freq.get, genGet),
+        (freq.head, genHead)
+        )
+          }
 
     private def genPost: Gen[Method.Post] = Gen.oneOf(genApi(0), genApi(200)).map(Method.Post)
     private def genGet: Gen[Method.Get]   = Gen.oneOf(fixedApis, genApi(0), genApi(1)).map(Method.Get)
@@ -48,16 +60,48 @@ object HttpRequest {
     eventPerPayloadMin: Int,
     eventPerPayloadMax: Int,
     now: Instant,
-    frequencies: EventFrequencies
-  ): Gen[HttpRequest] =
+    frequencies: EventFrequencies,
+    methodFrequencies: Option[MethodFrequencies]
+  ): Gen[HttpRequest] = {
+    // MethodFrequencies is an option here, at the entrypoint in order not to force a breaking change where this is a lib.
+    // If it's not provided, we give equal distribution to each to achieve behaviour parity
+    // From here in it's not an option, just to make the code a bit cleaner
+    val methodFreq = methodFrequencies.getOrElse(new MethodFrequencies(1, 1, 1))
     genWithParts(
       HttpRequestQuerystring.gen(now, frequencies),
-      HttpRequestBody.gen(eventPerPayloadMin, eventPerPayloadMax, now, frequencies)
+      HttpRequestBody.gen(eventPerPayloadMin, eventPerPayloadMax, now, frequencies),
+      methodFreq      
     )
+  }
 
-  private def genWithParts(qsGen: Gen[HttpRequestQuerystring], bodyGen: Gen[HttpRequestBody]) =
+  def genDup(
+    natProb: Float,
+    synProb: Float,
+    natTotal: Int,
+    synTotal: Int,
+    eventPerPayloadMin: Int,
+    eventPerPayloadMax: Int,
+    now: Instant,
+    frequencies: EventFrequencies,
+    methodFrequencies: Option[MethodFrequencies]
+  ): Gen[HttpRequest] = {
+    // MethodFrequencies is an option here, at the entrypoint in order not to force a breaking change where this is a lib.
+    // If it's not provided, we give equal distribution to each to achieve behaviour parity
+    // From here in it's not an option, just to make the code a bit cleaner
+    val methodFreq = methodFrequencies.getOrElse(new MethodFrequencies(1, 1, 1))
+    genWithParts(
+      // qs doesn't do duplicates?
+      HttpRequestQuerystring.gen(now, frequencies),
+      HttpRequestBody
+        .genDup(natProb, synProb, natTotal, synTotal, eventPerPayloadMin, eventPerPayloadMax, now, frequencies),
+      methodFreq
+    )
+  }
+    
+
+  private def genWithParts(qsGen: Gen[HttpRequestQuerystring], bodyGen: Gen[HttpRequestBody], methodFreq: MethodFrequencies) =
     for {
-      method <- Method.gen
+      method <- Method.gen(methodFreq)
       qs     <- Gen.option(qsGen)
       body <- method match {
         case Method.Head(_) => Gen.const(None) // HEAD requests can't have a message body

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -33,7 +33,7 @@ object Dependencies {
     val circe          = "0.14.1"
     val fs2Pubsub      = "0.22.0"
     val fs2Kafka       = "3.0.1"
-    val awsRegions     = "2.20.69"
+    val awsSdk         = "2.20.123"
     // Scala (test only)
     val specs2           = "4.12.3"
     val scalaCheck       = "1.14.0"
@@ -65,8 +65,8 @@ object Dependencies {
     val scalaCheckCats = "io.chrisdavenport"        %% "cats-scalacheck"              % V.scalaCheckCats
     val httpClient     = "org.apache.httpcomponents" % "httpclient"                   % V.httpClient
     val slf4j          = "org.slf4j"                 % "slf4j-simple"                 % V.slf4j
-    val kcl            = "software.amazon.kinesis"   % "amazon-kinesis-client"        % V.kcl
-    val awsRegions     = "software.amazon.awssdk"    % "regions"                      % V.awsRegions
+    val kcl            = "software.amazon.awssdk"    % "kinesis"                      % V.awsSdk
+    val awsRegions     = "software.amazon.awssdk"    % "regions"                      % V.awsSdk
     val http4sClient    = "org.http4s"        %% "http4s-blaze-client"           % V.http4s         
 
     // Scala (test only)

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -44,6 +44,7 @@ object Dependencies {
     val badRows          = "2.1.1"
     val httpClient       = "4.5.13"
     val thrift           = "0.15.0" // override transitive dependency to mitigate security vulnerabilities
+    val http4s = "0.23.15"
   }
 
   object Libraries {
@@ -66,6 +67,7 @@ object Dependencies {
     val slf4j          = "org.slf4j"                 % "slf4j-simple"                 % V.slf4j
     val kcl            = "software.amazon.kinesis"   % "amazon-kinesis-client"        % V.kcl
     val awsRegions     = "software.amazon.awssdk"    % "regions"                      % V.awsRegions
+    val http4sClient    = "org.http4s"        %% "http4s-blaze-client"           % V.http4s         
 
     // Scala (test only)
     val specs2           = "org.specs2" %% "specs2-core"       % V.specs2 % Test

--- a/sinks/src/main/resources/application.conf
+++ b/sinks/src/main/resources/application.conf
@@ -30,5 +30,11 @@
       "linkClick": 1
     }
   }
-
+  "methodFrequencies": {
+    # Setting these defaults becuase HEAD sink is not implemented yet,
+    # but it is still possibly in use as a library in our module tests
+        "post": 1
+        "get": 1
+        "head": 0
+    }
 }

--- a/sinks/src/main/scala/com.snowplowanalytics.snowplow.eventgen/Config.scala
+++ b/sinks/src/main/scala/com.snowplowanalytics.snowplow.eventgen/Config.scala
@@ -26,6 +26,7 @@ import io.circe.generic.extras.semiauto._
 
 import com.snowplowanalytics.snowplow.eventgen.protocol.event.EventFrequencies
 import com.snowplowanalytics.snowplow.eventgen.protocol.event.UnstructEventFrequencies
+import com.snowplowanalytics.snowplow.eventgen.tracker.HttpRequest.MethodFrequencies
 
 final case class Config(
   payloadsTotal: Int,
@@ -41,6 +42,7 @@ final case class Config(
   duplicates: Option[Config.Duplicates],
   timestamps: Config.Timestamps,
   eventFrequencies: EventFrequencies,
+  methodFrequencies: Option[MethodFrequencies],
   output: Config.Output
 )
 
@@ -69,6 +71,7 @@ object Config {
     case class File(path: URI) extends Output
     case class PubSub(subscription: String) extends Output
     case class Kafka(brokers: String, topic: String, producerConf: Map[String, String] = Map.empty) extends Output
+    case class Http(endpoint: org.http4s.Uri) extends Output
   }
 
   val configOpt   = Opts.option[Path]("config", "Path to the configuration HOCON").orNone
@@ -85,8 +88,11 @@ object Config {
   implicit val duplicatesDecoder: Decoder[Duplicates] =
     deriveConfiguredDecoder[Duplicates]
 
-  implicit val frequenciesDecoder: Decoder[EventFrequencies] =
+  implicit val eventFrequenciesDecoder: Decoder[EventFrequencies] =
     deriveConfiguredDecoder[EventFrequencies]
+
+  implicit val methodFrequenciesDecoder: Decoder[MethodFrequencies] =
+    deriveConfiguredDecoder [MethodFrequencies]
 
   implicit val unstructEventFrequenciesDecoder: Decoder[UnstructEventFrequencies] =
     deriveConfiguredDecoder[UnstructEventFrequencies]
@@ -95,6 +101,10 @@ object Config {
 
   implicit val uriDecoder: Decoder[URI] = Decoder[String].emap { str =>
     Either.catchOnly[IllegalArgumentException](URI.create(str)).leftMap(_.getMessage)
+  }
+
+  implicit val httpUriDecoder: Decoder[org.http4s.Uri] = Decoder[String].emap { str =>
+    org.http4s.Uri.fromString(str).leftMap(_.getMessage)
   }
 
   implicit val kafkaDecoder: Decoder[Output.Kafka] =
@@ -108,6 +118,9 @@ object Config {
 
   implicit val pubSubDecoder: Decoder[Output.PubSub] =
     deriveConfiguredDecoder[Output.PubSub]
+
+  implicit val httpDecoder: Decoder[Output.Http] =
+    deriveConfiguredDecoder[Output.Http]
 
   implicit val outputDecoder: Decoder[Output] =
     deriveConfiguredDecoder[Output]

--- a/sinks/src/main/scala/com.snowplowanalytics.snowplow.eventgen/Http.scala
+++ b/sinks/src/main/scala/com.snowplowanalytics.snowplow.eventgen/Http.scala
@@ -1,0 +1,112 @@
+/*
+ * Copyright (c) 2021-2023 Snowplow Analytics Ltd. All rights reserved.
+ *
+ * This program is licensed to you under the Apache License Version 2.0,
+ * and you may not use this file except in compliance with the Apache License Version 2.0.
+ * You may obtain a copy of the Apache License Version 2.0 at http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the Apache License Version 2.0 is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
+ */
+
+package com.snowplowanalytics.snowplow.eventgen
+
+import com.snowplowanalytics.snowplow.eventgen.tracker.HttpRequest
+import com.snowplowanalytics.snowplow.eventgen.tracker.HttpRequest.{Method => TrackerMethod}
+
+import fs2.{Pipe, Stream}
+
+import cats.syntax.all._
+
+import cats.effect.Async
+
+import org.http4s.ember.client.EmberClientBuilder
+import org.http4s.Request
+import org.http4s.Header.Raw
+import org.http4s.Method
+
+import org.typelevel.ci._
+import com.snowplowanalytics.snowplow.eventgen.tracker.HttpRequestQuerystring
+
+
+object Http {
+
+  def sink[F[_]: Async](properties: Config.Output.Http): Pipe[F, Main.GenOutput, Unit] = {
+
+    def buildRequesst(
+      generatedRequest: HttpRequest
+    ): Request[F] = {
+
+      // Origin headers are given to us a key and a comma separated string of values, 
+      // but we wish to attach each value as a header with the provided key ("Origin")
+      // This function provides a Seq of Raw headers (the type that putHeaders expects) 
+      // containing an item for each origin header, and an item each for the other headers.
+      def parseHeaders(headers: Map[String, String]): Seq[Raw] = {
+        headers
+          .map(kv => (kv._1, kv._2) match {
+            case (k, v) if k == "Origin" =>  
+              v.split(",")
+                .map(v => Raw(CIString(k), v))
+                .toSeq
+              
+              // Raw(CIString(k), v)
+            case (_, _) => Seq(Raw(CIString(kv._1), kv._2))
+          })
+          .toSeq
+          .flatten
+      }
+
+       // since /i requests have empty version, we pattern match to add the path.
+       // address is a var since we modify it when adding querystring
+       var address = generatedRequest.method.path.version match {
+        case "" => properties.endpoint / generatedRequest.method.path.vendor
+        case version: String  => properties.endpoint / generatedRequest.method.path.vendor / version
+       }
+
+      val body = generatedRequest.body match {
+        case Some(b) => b.toString()
+        case _       => ""
+      }
+
+      val req = generatedRequest.method match {
+
+        // POST requests: attach body, use the uri we already have, without adding querysring
+        case TrackerMethod.Post(_) =>
+          Request[F](method = Method.POST, uri = address).withEntity(body).putHeaders(parseHeaders(generatedRequest.headers))
+
+        // GET requests: add querystring, ignore body field
+        case TrackerMethod.Get(_) =>
+                    
+          // iterate querystring and add as kv pairs to the address
+          generatedRequest.qs match {
+            case None => address
+            case Some(querystring: HttpRequestQuerystring) => 
+              // val newUri = address
+              querystring.toProto
+              querystring.toProto.foreach(kv =>
+                address = address.withQueryParam(kv.getName(), kv.getValue())
+              )
+          }
+
+          Request[F](method = Method.GET, uri = address).putHeaders(parseHeaders(generatedRequest.headers))
+
+        // HEAD requests induce server errors that will take some digging to figure out.
+        // In the interest of getting to a usable tool quickly, for now we just throw an error for these.
+        case TrackerMethod.Head(_) => throw new NotImplementedError ( "HEAD requests not implemented" )
+      }
+
+      return req
+    }
+
+    val httpClient = EmberClientBuilder.default[F].build
+
+    st: Stream[F, Main.GenOutput] => {
+        Stream
+          .resource(httpClient)
+          .flatMap(client => 
+            st.map(_._3).map(buildRequesst).evalMap(req => client.status(req)).void)
+    }
+  }
+}

--- a/sinks/src/main/scala/com.snowplowanalytics.snowplow.eventgen/Main.scala
+++ b/sinks/src/main/scala/com.snowplowanalytics.snowplow.eventgen/Main.scala
@@ -24,7 +24,6 @@ import com.snowplowanalytics.snowplow.eventgen.protocol.event.UnstructEvent
 import software.amazon.awssdk.core.SdkBytes
 import software.amazon.awssdk.services.kinesis.KinesisAsyncClient
 import software.amazon.awssdk.services.kinesis.model.PutRecordRequest
-import software.amazon.kinesis.common.KinesisClientUtil
 import com.permutive.pubsub.producer.grpc.{GooglePubsubProducer, PubsubProducerConfig}
 import com.permutive.pubsub.producer.Model.{ProjectId, Topic}
 import com.permutive.pubsub.producer.encoder.MessageEncoder
@@ -180,9 +179,9 @@ object Main extends IOApp {
       }
       val kinesisClient: KinesisAsyncClient = output.region match {
         case Some(region) =>
-          KinesisClientUtil.createKinesisAsyncClient(KinesisAsyncClient.builder().region(Region.of(region)))
+          KinesisAsyncClient.builder.region(Region.of(region)).build
         case None =>
-          KinesisClientUtil.createKinesisAsyncClient(KinesisAsyncClient.builder())
+          KinesisAsyncClient.builder.build
       }
 
       def reqBuilder(event: Event): PutRecordRequest = PutRecordRequest

--- a/sinks/src/main/scala/com.snowplowanalytics.snowplow.eventgen/RotatingSink.scala
+++ b/sinks/src/main/scala/com.snowplowanalytics.snowplow.eventgen/RotatingSink.scala
@@ -13,7 +13,8 @@
 package com.snowplowanalytics.snowplow.eventgen
 
 import fs2.{Chunk, Pipe, Pull, Stream}
-import fs2.io.file.{Files, Flags, Path}
+import fs2.io.file.{Flags, Path}
+import fs2.io.file.Files.forAsync
 import fs2.concurrent.Channel
 
 import java.nio.file.{Paths => JPaths}
@@ -93,8 +94,8 @@ object RotatingSink {
 
   def file[F[_]: Async](prefix: String, suffix: String, idx: Int, baseDir: URI): Pipe[F, Byte, Nothing] = { in =>
     val catDir = Path.fromNioPath(JPaths.get(baseDir).resolve(prefix))
-    Stream.eval(Files[F].createDirectories(catDir)) *>
-      in.through(Files[F].writeAll(catDir.resolve(s"${prefix}_${pad(idx)}$suffix"), Flags.Write))
+    Stream.eval(forAsync[F].createDirectories(catDir)) *>
+      in.through(forAsync[F].writeAll(catDir.resolve(s"${prefix}_${pad(idx)}$suffix"), Flags.Write))
   }
 
   private def pad(idx: Int): String = f"$idx%10d"

--- a/sinks/src/main/scala/com.snowplowanalytics.snowplow.eventgen/Serializers.scala
+++ b/sinks/src/main/scala/com.snowplowanalytics.snowplow.eventgen/Serializers.scala
@@ -15,7 +15,7 @@ package com.snowplowanalytics.snowplow.eventgen
 import cats.effect.Sync
 import com.snowplowanalytics.snowplow.analytics.scalasdk.Event
 import fs2.{Pipe, Stream}
-import fs2.compression.Compression
+import fs2.compression.Compression.forSync
 import fs2.text.{base64, utf8}
 
 object Serializers {
@@ -23,7 +23,7 @@ object Serializers {
   def stringSerializer[F[_]: Sync](compress: Boolean): Pipe[F, String, Byte] = {
     val pipe: Pipe[F, String, Byte] = _.flatMap(x => Stream(x, "\n")).through(utf8.encode)
     if (compress)
-      pipe.andThen(Compression[F].gzip())
+      pipe.andThen(forSync[F].gzip())
     else
       pipe
   }


### PR DESCRIPTION
Draft PR for http sink.

Notes

- It's not perfect but it works - likely a lot of improvements could be made.
- Current implementation omits qs for post, omits body for get, and sends a hardcoded get for HEAD
- We still generate data for all formats every time, which is inefficient. I can see how to refactor it to improve this but don't have the time - it's already in an issue.
- I think it'd be beneficial to be able to configure paths/weights of the different path options - I hope to get to adding this separately for this release, but we don't need it for collector so I'm first going to move to the deployment of this asset as an RC.
- There is a bug whereby the data generated itself is producing corrupt context data sometimes - which when base64-encoded cx field results in a JSON with the character '7' at the end (When decoded). It results in enrichment failures - so not critical to current use case but I'll log an issue.


TODO this release:

- [x] Address review feedback
- [x] Make distribution of GET/POST/HEAD configurable
- [x] Fix origin headers
- [ ] Fix HEAD requests (or do something sensible with them) - Won't do - the server gives an error. Just leaving unimplemented for now.


To make tickets for:

- [x] Bug whereby cx field in querystring produces a `7` character at the end of the b64 when decoded: https://github.com/snowplow-incubator/snowplow-event-generator/issues/60
- [x] Make paths distribution configurable - this interacts with request type so needs some config design consideration: https://github.com/snowplow-incubator/snowplow-event-generator/issues/61
- [x] Make body/querystring generation configurable - sometimes we want a specific combination of both so needs some config design consideration: https://github.com/snowplow-incubator/snowplow-event-generator/issues/62
- [x] Refactor things function so that we run only the Gen functions we need rather than running all of them: https://github.com/snowplow-incubator/snowplow-event-generator/issues/63
- [x] Refactor things such that the same Body data is used for all 3 gen functions - so that for the same seed, different formats of the same data are produced: https://github.com/snowplow-incubator/snowplow-event-generator/issues/64



