### PR TITLE
derived_tstamp and etl_tstamp should always be defined

### DIFF
--- a/core/src/main/scala/com/snowplowanalytics/snowplow/eventgen/enrich/SdkEvent.scala
+++ b/core/src/main/scala/com/snowplowanalytics/snowplow/eventgen/enrich/SdkEvent.scala
@@ -85,7 +85,7 @@ object SdkEvent {
         case _                       => None
       }
 
-      val defaultEnrichment             = enrichments.flatMap(_.defaultEnrichment)
+      val defaultEnrichment             = enrichments.map(_.defaultEnrichment)
       val ipEnrichment                  = enrichments.flatMap(_.ipEnrichment)
       val urlEnrichment                 = enrichments.flatMap(_.urlEnrichment)
       val refererEnrichment             = enrichments.flatMap(_.refererEnrichment)
@@ -225,14 +225,14 @@ object SdkEvent {
         refr_dvce_tstamp = crossDomainEnrichment.flatMap(_.refr_dvce_tstamp),
         derived_contexts = el.derivedContexts.forSdkEvent,
         domain_sessionid = el.u.flatMap(_.sid.map(_.toString)),
-        derived_tstamp = defaultEnrichment.flatMap(_.derived_tstamp),
+        derived_tstamp = defaultEnrichment.map(_.derived_tstamp),
         event_vendor = ueVendor,
         event_name = eName,
         event_format = ueFormat,
         event_version = ueVersion,
         event_fingerprint = eventFingerprintEnrichment.flatMap(_.event_fingerprint),
         true_tstamp = el.dt.flatMap(_.ttm),
-        etl_tstamp = defaultEnrichment.flatMap(_.etl_tstamp)
+        etl_tstamp = defaultEnrichment.map(_.etl_tstamp)
       )
     }
 

--- a/core/src/main/scala/com/snowplowanalytics/snowplow/eventgen/protocol/enrichment/DefaultEnrichment.scala
+++ b/core/src/main/scala/com/snowplowanalytics/snowplow/eventgen/protocol/enrichment/DefaultEnrichment.scala
@@ -19,14 +19,14 @@ import org.scalacheck.Gen
 import org.scalacheck.cats.implicits._
 
 case class DefaultEnrichment(
-  derived_tstamp: Option[Instant],
-  etl_tstamp: Option[Instant]
+  derived_tstamp: Instant,
+  etl_tstamp: Instant
 )
 
 object DefaultEnrichment {
   def gen: Gen[DefaultEnrichment] =
     (
-      genInstantOpt(Instant.now),
-      genInstantOpt(Instant.now)
+      genInstant(Instant.now),
+      genInstant(Instant.now)
     ).mapN(DefaultEnrichment.apply)
 }

--- a/core/src/main/scala/com/snowplowanalytics/snowplow/eventgen/protocol/enrichment/Enrichments.scala
+++ b/core/src/main/scala/com/snowplowanalytics/snowplow/eventgen/protocol/enrichment/Enrichments.scala
@@ -17,7 +17,7 @@ import org.scalacheck.Gen
 import org.scalacheck.cats.implicits._
 
 final case class Enrichments(
-  defaultEnrichment: Option[DefaultEnrichment],
+  defaultEnrichment: DefaultEnrichment,
   ipEnrichment: Option[IpEnrichment],
   urlEnrichment: Option[UrlEnrichment],
   refererEnrichment: Option[RefererEnrichment],
@@ -32,7 +32,7 @@ object Enrichments {
 
   def gen: Gen[Enrichments] =
     (
-      Gen.option(DefaultEnrichment.gen),
+      DefaultEnrichment.gen,
       Gen.option(IpEnrichment.gen),
       Gen.option(UrlEnrichment.gen),
       Gen.option(RefererEnrichment.gen),


### PR DESCRIPTION
Previously, this app generated events with undefined `etl_tstamp` and `derived_tstamp`, even when enrichments are enabled.  This old behaviour was defensible because the purpose of this app is to generate all edge cases of possible events.

However, if you look at the Enrich code, it is completely impossible for those timestamps to be null:
- `etl_tstamp` is set [here](https://github.com/snowplow/enrich/blob/4.2.0/modules/common/src/main/scala/com.snowplowanalytics.snowplow.enrich/common/enrichments/EnrichmentManager.scala#L323)
- For `derived_tstamp`, see [these comments](https://github.com/snowplow/enrich/blob/4.2.0/modules/common/src/main/scala/com.snowplowanalytics.snowplow.enrich/common/enrichments/EventEnrichments.scala#L69-L71) to see why it is always set.

I think it is reasonable to say a valid enriched event **must** have non-null `etl_tstamp` and `derived_tstamp`.  Then this event-generator can be used for testing downstream tooling that depend on those fields.