### PR TITLE
Fix performance bottleneck in event generation

### DIFF
--- a/core/src/main/scala/com/snowplowanalytics/snowplow/eventgen/primitives/package.scala
+++ b/core/src/main/scala/com/snowplowanalytics/snowplow/eventgen/primitives/package.scala
@@ -18,6 +18,7 @@ import org.scalacheck.{Arbitrary, Gen}
 import java.nio.charset.Charset
 import java.time.Instant
 import java.util.{Base64, TimeZone}
+import scala.jdk.CollectionConverters._
 import scala.util.Random
 
 package object primitives {
@@ -57,7 +58,9 @@ package object primitives {
 
   def genInstantOpt(now: Instant): Gen[Option[Instant]] = Gen.option(genInstant(now))
 
-  def genTz: Gen[String] = Gen.oneOf(TimeZone.getAvailableIDs.toSeq)
+  // Cache timezone IDs - TimeZone.getAvailableIDs is expensive
+  private val timezoneIds: Seq[String] = TimeZone.getAvailableIDs.toSeq
+  def genTz: Gen[String]               = Gen.oneOf(timezoneIds)
 
   def genTzOpt: Gen[Option[String]] = Gen.option(genTz)
 
@@ -84,7 +87,9 @@ package object primitives {
 
   def genUserAgentOpt: Gen[Option[String]] = Gen.option(genUserAgent)
 
-  def genCharsetStr: Gen[String] = Gen.oneOf(Charset.availableCharsets().keySet().toArray.toSeq.map(_.toString))
+  // Cache charset list - Charset.availableCharsets() is expensive (system call)
+  private val charsetNames: Seq[String] = Charset.availableCharsets().keySet().asScala.toSeq
+  def genCharsetStr: Gen[String]        = Gen.oneOf(charsetNames)
 
   def genCharsetStrOpt: Gen[Option[String]] = Gen.option(genCharsetStr)
 

--- a/sinks/src/main/scala/com.snowplowanalytics.snowplow.eventgen/Main.scala
+++ b/sinks/src/main/scala/com.snowplowanalytics.snowplow.eventgen/Main.scala
@@ -86,7 +86,7 @@ object Main extends IOApp {
             .flatMap(nbEvents => Sync[F].delay(println(s"$nbEvents events generated in the last $reportPeriod")))
         }
 
-        events.through(sink).evalTap(_ => counts.update(_ + 1)).concurrently(showCounts)
+        events.evalTap(_ => counts.update(_ + 1)).through(sink).concurrently(showCounts)
       }
       .compile
       .drain


### PR DESCRIPTION
Profiling revealed Charset.availableCharsets() and TimeZone.getAvailableIDs were being called on every event generation - expensive system calls that scan available charsets/timezones.

These are JVM constants that don't change at runtime, so cached them as private vals. Also fix event counter to count before sink instead of after, so it works correctly with all sink types.

Take my numbers with a pinch of salt but locally with http+stdout and no rate limiting i went from ~420k to ~700k events per minute.