### PR TITLE
Limit app_id cardinality

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -77,9 +77,6 @@ lazy val sinks = project
       Dependencies.Libraries.http4sCirce,
       Dependencies.Libraries.catsRetry
     )
-    // libraryDependencies += "org.typelevel" %% "cats-effect" % "3.4.6",
-    // libraryDependencies += "org.http4s"    %% "http4s-ember-client" % "0.23.15",
-    // libraryDependencies += "org.http4s" %% "http4s-circe" % "0.23.15"
   )
   .dependsOn(core)
 

--- a/build.sbt
+++ b/build.sbt
@@ -76,8 +76,8 @@ lazy val sinks = project
       Dependencies.Libraries.http4sEmber,
       Dependencies.Libraries.http4sCirce,
       Dependencies.Libraries.catsRetry
-    ),
-    //libraryDependencies += "org.typelevel" %% "cats-effect" % "3.4.6",
+    )
+    // libraryDependencies += "org.typelevel" %% "cats-effect" % "3.4.6",
     // libraryDependencies += "org.http4s"    %% "http4s-ember-client" % "0.23.15",
     // libraryDependencies += "org.http4s" %% "http4s-circe" % "0.23.15"
   )

--- a/config/config.example.hocon
+++ b/config/config.example.hocon
@@ -65,9 +65,10 @@
     # "at": "2022-02-01T01:01:01z"
   }
 
-  # Optional. App ID to use in the events
-  # If not set, each event will get a new app ID
-  # "appId": "my-app"
+  # Optional. List of App IDs to use in the events
+  # Each event will get a randomly selected app ID from this list
+  # If not set, defaults to ["event-gen-1", "event-gen-2", ..., "event-gen-10"]
+  # "appIds": ["my-app-1", "my-app-2", "my-app-3"]
 
   # Optional. Seed to use to generate events
   # For a same seed, the same event will get deterministically generated
@@ -94,6 +95,8 @@
     "unstruct": 1
     "pageView": 1
     "pagePing": 1
+    "transaction": 1
+    "transactionItem": 1
     "unstructEventFrequencyDefault": 1
     "unstructEventFrequencies": {
       "change_form": 1

--- a/core/src/main/scala/com/snowplowanalytics/snowplow/eventgen/collector/CollectorPayload.scala
+++ b/core/src/main/scala/com/snowplowanalytics/snowplow/eventgen/collector/CollectorPayload.scala
@@ -118,11 +118,12 @@ object CollectorPayload {
     eventsPerPayload: GenConfig.EventsPerPayload,
     time: Instant,
     frequencies: GenConfig.EventsFrequencies,
-    contexts: GenConfig.ContextsPerEvent
+    contexts: GenConfig.ContextsPerEvent,
+    appIds: List[String]
   ): Gen[CollectorPayload] =
     genWithBody(
       eventsPerPayload,
-      Body.genDup(duplicates, time, frequencies, contexts),
+      Body.genDup(duplicates, time, frequencies, contexts, appIds),
       time
     )
 
@@ -139,9 +140,10 @@ object CollectorPayload {
     eventsPerPayload: GenConfig.EventsPerPayload,
     time: Instant,
     frequencies: GenConfig.EventsFrequencies,
-    contexts: GenConfig.ContextsPerEvent
+    contexts: GenConfig.ContextsPerEvent,
+    appIds: List[String]
   ): Gen[CollectorPayload] =
-    genWithBody(eventsPerPayload, Body.gen(time, frequencies, contexts), time)
+    genWithBody(eventsPerPayload, Body.gen(time, frequencies, contexts, appIds), time)
 
   val IgluUri: SchemaKey =
     SchemaKey("com.snowplowanalytics.snowplow", "CollectorPayload", "thrift", SchemaVer.Full(1, 0, 0))

--- a/core/src/main/scala/com/snowplowanalytics/snowplow/eventgen/enrich/SdkEvent.scala
+++ b/core/src/main/scala/com/snowplowanalytics/snowplow/eventgen/enrich/SdkEvent.scala
@@ -46,8 +46,7 @@ object SdkEvent {
   private def eventsFromColPayload(
     p: CollectorPayload,
     fallbackEid: UUID,
-    enrichments: Option[Enrichments],
-    appId: Option[String]
+    enrichments: Option[Enrichments]
   ): List[Event] =
     p.payload.map { el =>
       val evnt = Some(el.e match {
@@ -98,7 +97,7 @@ object SdkEvent {
       val deprecatedFields              = enrichments.flatMap(_.deprecatedFields)
 
       Event(
-        app_id = appId.orElse(el.app.aid),
+        app_id = el.app.aid,
         platform = Some(el.app.p),
         collector_tstamp = p.context.timestamp,
         dvce_created_tstamp = el.dt.flatMap(_.dtm),
@@ -244,13 +243,13 @@ object SdkEvent {
     frequencies: GenConfig.EventsFrequencies,
     contexts: GenConfig.ContextsPerEvent,
     generateEnrichments: Boolean,
-    appId: Option[String]
+    appIds: List[String]
   ): Gen[List[Event]] =
     for {
-      cp          <- CollectorPayload.gen(eventsPerPayload, time, frequencies, contexts)
+      cp          <- CollectorPayload.gen(eventsPerPayload, time, frequencies, contexts, appIds)
       enrichments <- if (generateEnrichments) Enrichments.gen.map(Some(_)) else Gen.const(None)
       eid         <- Gen.uuid
-    } yield eventsFromColPayload(cp, eid, enrichments, appId)
+    } yield eventsFromColPayload(cp, eid, enrichments)
 
   def genDup(
     duplicates: GenConfig.Duplicates,
@@ -259,7 +258,7 @@ object SdkEvent {
     frequencies: GenConfig.EventsFrequencies,
     contexts: GenConfig.ContextsPerEvent,
     generateEnrichments: Boolean,
-    appId: Option[String]
+    appIds: List[String]
   ): Gen[List[Event]] =
     for {
       cp <- CollectorPayload.genDup(
@@ -267,9 +266,10 @@ object SdkEvent {
         eventsPerPayload,
         time,
         frequencies,
-        contexts
+        contexts,
+        appIds
       )
       enrichments <- if (generateEnrichments) Enrichments.gen.map(Some(_)) else Gen.const(None)
       eid         <- Gen.uuid
-    } yield eventsFromColPayload(cp, eid, enrichments, appId)
+    } yield eventsFromColPayload(cp, eid, enrichments)
 }

--- a/core/src/main/scala/com/snowplowanalytics/snowplow/eventgen/protocol/Body.scala
+++ b/core/src/main/scala/com/snowplowanalytics/snowplow/eventgen/protocol/Body.scala
@@ -101,7 +101,12 @@ object Body {
       derivedContexts <- Context.DerivedContextsWrapper.gen(time)
     } yield Body(e, app, dt, dev, tv, et, u, event, contexts, derivedContexts)
 
-  def gen(time: Instant, frequencies: GenConfig.EventsFrequencies, contexts: GenConfig.ContextsPerEvent, appIds: List[String]): Gen[Body] =
+  def gen(
+    time: Instant,
+    frequencies: GenConfig.EventsFrequencies,
+    contexts: GenConfig.ContextsPerEvent,
+    appIds: List[String]
+  ): Gen[Body] =
     genWithEt(EventTransaction.gen, time, frequencies, contexts, appIds)
 
   def encodeValue(value: String) = URLEncoder.encode(value, StandardCharsets.UTF_8.toString)

--- a/core/src/main/scala/com/snowplowanalytics/snowplow/eventgen/protocol/Body.scala
+++ b/core/src/main/scala/com/snowplowanalytics/snowplow/eventgen/protocol/Body.scala
@@ -62,9 +62,10 @@ object Body {
     duplicates: GenConfig.Duplicates,
     time: Instant,
     frequencies: GenConfig.EventsFrequencies,
-    contexts: GenConfig.ContextsPerEvent
+    contexts: GenConfig.ContextsPerEvent,
+    appIds: List[String]
   ): Gen[Body] =
-    genWithEt(EventTransaction.genDup(duplicates.synProb, duplicates.synTotal), time, frequencies, contexts)
+    genWithEt(EventTransaction.genDup(duplicates.synProb, duplicates.synTotal), time, frequencies, contexts, appIds)
       .withPerturb(in =>
         if (duplicates.natProb == 0f | duplicates.natTotal == 0)
           in
@@ -77,11 +78,12 @@ object Body {
     etGen: Gen[EventTransaction],
     time: Instant,
     frequencies: GenConfig.EventsFrequencies,
-    contexts: GenConfig.ContextsPerEvent
+    contexts: GenConfig.ContextsPerEvent,
+    appIds: List[String]
   ) =
     for {
       e   <- EventType.gen(frequencies)
-      app <- Application.gen
+      app <- Application.gen(appIds)
       et  <- etGen
       dt  <- DateTime.genOpt(time)
       dev <- Device.genOpt
@@ -99,8 +101,8 @@ object Body {
       derivedContexts <- Context.DerivedContextsWrapper.gen(time)
     } yield Body(e, app, dt, dev, tv, et, u, event, contexts, derivedContexts)
 
-  def gen(time: Instant, frequencies: GenConfig.EventsFrequencies, contexts: GenConfig.ContextsPerEvent): Gen[Body] =
-    genWithEt(EventTransaction.gen, time, frequencies, contexts)
+  def gen(time: Instant, frequencies: GenConfig.EventsFrequencies, contexts: GenConfig.ContextsPerEvent, appIds: List[String]): Gen[Body] =
+    genWithEt(EventTransaction.gen, time, frequencies, contexts, appIds)
 
   def encodeValue(value: String) = URLEncoder.encode(value, StandardCharsets.UTF_8.toString)
 }

--- a/core/src/main/scala/com/snowplowanalytics/snowplow/eventgen/protocol/common/Application.scala
+++ b/core/src/main/scala/com/snowplowanalytics/snowplow/eventgen/protocol/common/Application.scala
@@ -34,11 +34,10 @@ final case class Application(
 }
 
 object Application {
-  def gen: Gen[Application] =
+  def gen(appIds: List[String]): Gen[Application] =
     (
       Gen.oneOf("web", "mob", "pc", "srv", "app", "tv", "cnsl", "iot"),
-      genStringOpt("aid", 10),
-//    genStringOpt("evn", 10),
+      Gen.oneOf(appIds).map(Some(_)),
       genStringOpt("tna", 10)
     ).mapN(Application.apply)
 }

--- a/core/src/main/scala/com/snowplowanalytics/snowplow/eventgen/tracker/HttpRequest.scala
+++ b/core/src/main/scala/com/snowplowanalytics/snowplow/eventgen/tracker/HttpRequest.scala
@@ -54,15 +54,16 @@ object HttpRequest {
     time: Instant,
     frequencies: GenConfig.EventsFrequencies,
     contexts: GenConfig.ContextsPerEvent,
-    methodFrequencies: Option[GenConfig.Events.Http.MethodFrequencies]
+    methodFrequencies: Option[GenConfig.Events.Http.MethodFrequencies],
+    appIds: List[String]
   ): Gen[HttpRequest] = {
     // MethodFrequencies is an option here, at the entrypoint in order not to force a breaking change where this is a lib.
     // If it's not provided, we give equal distribution to each to achieve behaviour parity
     // From here in it's not an option, just to make the code a bit cleaner
     val methodFreq = methodFrequencies.getOrElse(new GenConfig.Events.Http.MethodFrequencies(1, 1, 1))
     genWithParts(
-      HttpRequestQuerystring.gen(time, frequencies, contexts),
-      HttpRequestBody.gen(eventsPerPayload, time, frequencies, contexts),
+      HttpRequestQuerystring.gen(time, frequencies, contexts, appIds),
+      HttpRequestBody.gen(eventsPerPayload, time, frequencies, contexts, appIds),
       methodFreq
     )
   }
@@ -73,7 +74,8 @@ object HttpRequest {
     time: Instant,
     frequencies: GenConfig.EventsFrequencies,
     contexts: GenConfig.ContextsPerEvent,
-    methodFrequencies: Option[GenConfig.Events.Http.MethodFrequencies]
+    methodFrequencies: Option[GenConfig.Events.Http.MethodFrequencies],
+    appIds: List[String]
   ): Gen[HttpRequest] = {
     // MethodFrequencies is an option here, at the entrypoint in order not to force a breaking change where this is a lib.
     // If it's not provided, we give equal distribution to each to achieve behaviour parity
@@ -81,13 +83,14 @@ object HttpRequest {
     val methodFreq = methodFrequencies.getOrElse(new GenConfig.Events.Http.MethodFrequencies(1, 1, 1))
     genWithParts(
       // qs doesn't do duplicates?
-      HttpRequestQuerystring.gen(time, frequencies, contexts),
+      HttpRequestQuerystring.gen(time, frequencies, contexts, appIds),
       HttpRequestBody.genDup(
         duplicates,
         eventsPerPayload,
         time,
         frequencies,
-        contexts
+        contexts,
+        appIds
       ),
       methodFreq
     )

--- a/core/src/main/scala/com/snowplowanalytics/snowplow/eventgen/tracker/HttpRequestBody.scala
+++ b/core/src/main/scala/com/snowplowanalytics/snowplow/eventgen/tracker/HttpRequestBody.scala
@@ -35,17 +35,19 @@ object HttpRequestBody {
     evenstPerPayload: GenConfig.EventsPerPayload,
     time: Instant,
     frequencies: GenConfig.EventsFrequencies,
-    contexts: GenConfig.ContextsPerEvent
+    contexts: GenConfig.ContextsPerEvent,
+    appIds: List[String]
   ): Gen[HttpRequestBody] =
-    genWithBody(evenstPerPayload, Body.genDup(duplicates, time, frequencies, contexts))
+    genWithBody(evenstPerPayload, Body.genDup(duplicates, time, frequencies, contexts, appIds))
 
   def gen(
     evenstPerPayload: GenConfig.EventsPerPayload,
     time: Instant,
     frequencies: GenConfig.EventsFrequencies,
-    contexts: GenConfig.ContextsPerEvent
+    contexts: GenConfig.ContextsPerEvent,
+    appIds: List[String]
   ): Gen[HttpRequestBody] =
-    genWithBody(evenstPerPayload, Body.gen(time, frequencies, contexts))
+    genWithBody(evenstPerPayload, Body.gen(time, frequencies, contexts, appIds))
 
   private def genWithBody(
     evenstPerPayload: GenConfig.EventsPerPayload,

--- a/core/src/main/scala/com/snowplowanalytics/snowplow/eventgen/tracker/HttpRequestQuerystring.scala
+++ b/core/src/main/scala/com/snowplowanalytics/snowplow/eventgen/tracker/HttpRequestQuerystring.scala
@@ -29,10 +29,11 @@ object HttpRequestQuerystring {
   def gen(
     time: Instant,
     frequencies: GenConfig.EventsFrequencies,
-    contexts: GenConfig.ContextsPerEvent
+    contexts: GenConfig.ContextsPerEvent,
+    appIds: List[String]
   ): Gen[HttpRequestQuerystring] =
     genWithBody(
-      Body.gen(time, frequencies, contexts)
+      Body.gen(time, frequencies, contexts, appIds)
     )
 
   private def genWithBody(bodyGen: Gen[Body]) =

--- a/project/BuildSettings.scala
+++ b/project/BuildSettings.scala
@@ -95,9 +95,9 @@ object BuildSettings {
       case PathList("buildinfo", _)             => MergeStrategy.first
       case x if x.contains("javax")             => MergeStrategy.first
       case PathList("scala", "annotation", "nowarn.class" | "nowarn$.class") => MergeStrategy.first // http4s, 2.13 shim
-      case x if x.endsWith(".proto") => MergeStrategy.first // proto files
-      case x if x.endsWith(".properties") => MergeStrategy.first
-      case x if x.endsWith("reflection-config.json") => MergeStrategy.first
+      case x if x.endsWith(".proto")                                         => MergeStrategy.first // proto files
+      case x if x.endsWith(".properties")                                    => MergeStrategy.first
+      case x if x.endsWith("reflection-config.json")                         => MergeStrategy.first
       case x =>
         val oldStrategy = (assembly / assemblyMergeStrategy).value
         oldStrategy(x)

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -72,7 +72,7 @@ object Dependencies {
     val http4sClient   = "org.http4s"               %% "http4s-blaze-client"          % V.http4s
     val stsSdk         = "software.amazon.awssdk"    % "sts"                          % V.awsSdk
     val http4sEmber    = "org.http4s"               %% "http4s-ember-client"          % V.http4s
-    val http4sCirce    =  "org.http4s"              %% "http4s-circe"                 % V.http4s
+    val http4sCirce    = "org.http4s"               %% "http4s-circe"                 % V.http4s
 
     // Scala (test only)
     val specs2           = "org.specs2" %% "specs2-core"       % V.specs2 % Test
@@ -84,6 +84,6 @@ object Dependencies {
     // raw output
     val snowplowRawEvent = "com.snowplowanalytics"  % "snowplow-thrift-raw-event" % V.snowplowRawEvent
     val collectorPayload = "com.snowplowanalytics"  % "collector-payload-1"       % V.collectorPayload
-    val badRows          = "com.snowplowanalytics"  %% "snowplow-badrows"          % V.badRows
+    val badRows          = "com.snowplowanalytics" %% "snowplow-badrows"          % V.badRows
   }
 }

--- a/sinks/src/main/resources/application.conf
+++ b/sinks/src/main/resources/application.conf
@@ -2,6 +2,7 @@
   "timestamp": {
     "type": "Now"
   }
+  "appIds": ["event-gen-1", "event-gen-2", "event-gen-3", "event-gen-4", "event-gen-5", "event-gen-6", "event-gen-7", "event-gen-8", "event-gen-9", "event-gen-10"]
   "eventsPerPayload": {
     "min": 1
     "max": 3

--- a/sinks/src/main/scala/com.snowplowanalytics.snowplow.eventgen/Config.scala
+++ b/sinks/src/main/scala/com.snowplowanalytics.snowplow.eventgen/Config.scala
@@ -31,7 +31,7 @@ final case class Config(
   output: Config.Output,
   eventsTotal: Option[Long],
   timestamp: Config.Timestamp,
-  appId: Option[String],
+  appIds: List[String],
   seed: Option[Long],
   eventsPerPayload: GenConfig.EventsPerPayload,
   eventsFrequencies: GenConfig.EventsFrequencies,

--- a/sinks/src/main/scala/com.snowplowanalytics.snowplow.eventgen/Gen.scala
+++ b/sinks/src/main/scala/com.snowplowanalytics.snowplow.eventgen/Gen.scala
@@ -31,14 +31,16 @@ object Gen {
           config.eventsPerPayload,
           time,
           config.eventsFrequencies,
-          config.contextsPerEvent
+          config.contextsPerEvent,
+          config.appIds
         )
       case None =>
         CollectorPayload.gen(
           config.eventsPerPayload,
           time,
           config.eventsFrequencies,
-          config.contextsPerEvent
+          config.contextsPerEvent,
+          config.appIds
         )
     }
 
@@ -57,7 +59,7 @@ object Gen {
           config.eventsFrequencies,
           config.contextsPerEvent,
           generateEnrichments,
-          config.appId
+          config.appIds
         )
       case None =>
         SdkEvent.gen(
@@ -66,7 +68,7 @@ object Gen {
           config.eventsFrequencies,
           config.contextsPerEvent,
           generateEnrichments,
-          config.appId
+          config.appIds
         )
     }
 
@@ -91,7 +93,8 @@ object Gen {
           time,
           config.eventsFrequencies,
           config.contextsPerEvent,
-          methodFrequencies
+          methodFrequencies,
+          config.appIds
         )
       case None =>
         HttpRequest.gen(
@@ -99,7 +102,8 @@ object Gen {
           time,
           config.eventsFrequencies,
           config.contextsPerEvent,
-          methodFrequencies
+          methodFrequencies,
+          config.appIds
         )
     }
 }


### PR DESCRIPTION
Instead of generating a unique app_id per event, events now randomly select from a configurable list of app_ids. Defaults to 10 values (event-gen-1 through event-gen-10).

ref: https://snplow.atlassian.net/browse/PDP-2393