### PR TITLE
Bump to Java 25

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,11 +15,11 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: coursier/cache-action@v6
-      - name: Set up JDK 11
+      - name: Set up JDK 25
         uses: actions/setup-java@v2
         with:
-          java-version: 11
-          distribution: adopt
+          java-version: 25
+          distribution: temurin
       - name: Install sbt
         uses: sbt/setup-sbt@v1
       - name: Run tests
@@ -32,11 +32,11 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: coursier/cache-action@v6
-      - name: Set up JDK 11
+      - name: Set up JDK 25
         uses: actions/setup-java@v2
         with:
-          java-version: 11
-          distribution: adopt
+          java-version: 25
+          distribution: temurin
       - name: Install sbt
         uses: sbt/setup-sbt@v1
       - name: Get current version
@@ -78,11 +78,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Set up JDK 11
+      - name: Set up JDK 25
         uses: actions/setup-java@v2
         with:
-          java-version: 11
-          distribution: adopt
+          java-version: 25
+          distribution: temurin
       - name: Install sbt
         uses: sbt/setup-sbt@v1
       - name: Deploy common on Bintray Maven and Maven Central
@@ -100,11 +100,11 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: coursier/cache-action@v6
-      - name: Set up JDK 11
+      - name: Set up JDK 25
         uses: actions/setup-java@v2
         with:
-          java-version: 11
-          distribution: adopt
+          java-version: 25
+          distribution: temurin
       - name: Install sbt
         uses: sbt/setup-sbt@v1
       - name: Get current version

--- a/build.sbt
+++ b/build.sbt
@@ -23,7 +23,7 @@ lazy val core = project
   .settings(
     moduleName := "snowplow-event-generator-core",
     description := "Generate random enriched events",
-    crossScalaVersions := Seq("2.12.14", "2.13.6")
+    crossScalaVersions := Seq("2.12.21", "2.13.18")
   )
   .enablePlugins(SiteScaladocPlugin, DockerPlugin, JavaAppPackaging)
   .settings(commonSettings)

--- a/flake.nix
+++ b/flake.nix
@@ -22,7 +22,7 @@
           config.allowUnfree = true;
           config.allowUnsupportedSystem = true;
         };
-        jre = pkgs.openjdk11;
+        jre = pkgs.openjdk25;
         sbt = pkgs.sbt.override {inherit jre;};
         coursier = pkgs.coursier.override {inherit jre;};
         metals = pkgs.metals.override {inherit coursier jre;};

--- a/project/BuildSettings.scala
+++ b/project/BuildSettings.scala
@@ -34,7 +34,12 @@ object BuildSettings {
     description := "Generate random events",
     organization := "com.snowplowanalytics",
     scalaVersion := "2.13.18",
-    licenses += ("Apache-2.0", url("https://www.apache.org/licenses/LICENSE-2.0"))
+    licenses += ("Apache-2.0", url("https://www.apache.org/licenses/LICENSE-2.0")),
+    libraryDependencySchemes ++= Seq(
+      "io.circe" %% "circe-core"    % VersionScheme.Always,
+      "io.circe" %% "circe-generic" % VersionScheme.Always,
+      "io.circe" %% "circe-parser"  % VersionScheme.Always
+    )
   )
 
   lazy val basicSettigns = Seq(

--- a/project/BuildSettings.scala
+++ b/project/BuildSettings.scala
@@ -33,7 +33,7 @@ object BuildSettings {
     name := "snowplow-event-generator",
     description := "Generate random events",
     organization := "com.snowplowanalytics",
-    scalaVersion := "2.13.6",
+    scalaVersion := "2.13.18",
     licenses += ("Apache-2.0", url("https://www.apache.org/licenses/LICENSE-2.0"))
   )
 
@@ -49,7 +49,7 @@ object BuildSettings {
   /** Docker image settings */
   lazy val dockerSettings = Seq(
     Docker / maintainer := "Snowplow Analytics Ltd. <support@snowplowanalytics.com>",
-    dockerBaseImage := "adoptopenjdk:11-jre-hotspot-focal",
+    dockerBaseImage := "eclipse-temurin:25-jre-noble",
     Docker / daemonUser := "daemon",
     dockerUpdateLatest := true,
     dockerRepository := Some("snowplow"),

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -23,32 +23,33 @@ object Dependencies {
   object V {
     // Scala
     val analyticsSdk   = "2.1.0"
-    val fs2            = "3.1.1"
-    val decline        = "2.1.0"
+    val fs2            = "3.11.0"
+    val decline        = "2.5.0"
     val blobstore      = "0.9.5"
     val scalaCheckCats = "0.3.1"
     val catsRetry      = "3.1.3"
     val kcl            = "2.4.0"
     val slf4j          = "1.7.32"
-    val circeConfig    = "0.8.0"
-    val circe          = "0.14.1"
+    val circeConfig    = "0.10.1"
+    val circe          = "0.14.10"
+    val circeExtras    = "0.14.4"
     val fs2Pubsub      = "0.22.0"
-    val fs2Kafka       = "3.0.1"
-    val awsSdk         = "2.20.123"
+    val fs2Kafka       = "3.9.1"
+    val awsSdk         = "2.35.9"
     // Scala (test only)
-    val specs2           = "4.12.3"
-    val scalaCheck       = "1.14.0"
-    val collectionCompat = "2.4.4"
+    val specs2           = "4.21.0"
+    val scalaCheck       = "1.18.1"
+    val collectionCompat = "2.14.0"
     val igluClient       = "3.1.0"
-    val catsEffect       = "3.4.5"
-    val catsEffectSpecs2 = "1.5.0"
+    val catsEffect       = "3.7.0"
+    val catsEffectSpecs2 = "1.6.0"
     // raw output
     val snowplowRawEvent = "0.1.0"
     val collectorPayload = "0.0.0"
     val badRows          = "2.1.1"
-    val httpClient       = "4.5.13"
-    val thrift           = "0.15.0" // override transitive dependency to mitigate security vulnerabilities
-    val http4s           = "0.23.15"
+    val httpClient       = "4.5.14"
+    val thrift           = "0.22.0"
+    val http4s           = "0.23.33"
   }
 
   object Libraries {
@@ -64,7 +65,7 @@ object Dependencies {
     val circeConfig    = "io.circe"                 %% "circe-config"                 % V.circeConfig
     val circeGeneric   = "io.circe"                 %% "circe-generic"                % V.circe
     val circeParser    = "io.circe"                 %% "circe-parser"                 % V.circe
-    val circeExtras    = "io.circe"                 %% "circe-generic-extras"         % V.circe
+    val circeExtras    = "io.circe"                 %% "circe-generic-extras"         % V.circeExtras
     val scalaCheck     = "org.scalacheck"           %% "scalacheck"                   % V.scalaCheck
     val scalaCheckCats = "io.chrisdavenport"        %% "cats-scalacheck"              % V.scalaCheckCats
     val catsRetry      = "com.github.cb372"         %% "cats-retry"                   % V.catsRetry

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.8.2
+sbt.version=1.12.7

--- a/sinks/src/main/scala/com.snowplowanalytics.snowplow.eventgen/Main.scala
+++ b/sinks/src/main/scala/com.snowplowanalytics.snowplow.eventgen/Main.scala
@@ -19,6 +19,7 @@ import scala.concurrent.duration.DurationInt
 import org.scalacheck.{Gen => ScalaGen}
 
 import fs2.{Pipe, Stream}
+import fs2.io.net.Network
 
 import cats.syntax.all._
 
@@ -52,7 +53,7 @@ object Main extends IOApp {
   private def printCounts(gens: List[SelfDescribingJsonGen]): String =
     gens.map(g => s"  ${g.schemaKey.toSchemaUri} = ${g.genCount}").mkString("\n")
 
-  private def generate[F[_]: Async](config: Config): F[Unit] = {
+  private def generate[F[_]: Async: Network](config: Config): F[Unit] = {
 
     val sink: Sink[F] = Sink.make(config.output)
 

--- a/sinks/src/main/scala/com.snowplowanalytics.snowplow.eventgen/sinks/Http.scala
+++ b/sinks/src/main/scala/com.snowplowanalytics.snowplow.eventgen/sinks/Http.scala
@@ -21,6 +21,8 @@ import cats.syntax.all._
 
 import cats.effect.kernel.Async
 
+import fs2.io.net.Network
+
 import org.http4s.ember.client.EmberClientBuilder
 import org.http4s.Request
 import org.http4s.Header.Raw
@@ -34,7 +36,7 @@ import com.snowplowanalytics.snowplow.eventgen.Config
 
 object Http {
 
-  def make[F[_]: Async](config: Config.Output.Http) = new Sink[F] {
+  def make[F[_]: Async: Network](config: Config.Output.Http) = new Sink[F] {
 
     override def collectorPayload: Pipe[F, CollectorPayload, Unit] =
       _ => Stream.raiseError(new IllegalStateException(s"Can't use HTTP output for Thrift collector payloads"))

--- a/sinks/src/main/scala/com.snowplowanalytics.snowplow.eventgen/sinks/Kinesis.scala
+++ b/sinks/src/main/scala/com.snowplowanalytics.snowplow.eventgen/sinks/Kinesis.scala
@@ -23,8 +23,6 @@ import software.amazon.awssdk.regions.Region
 
 import fs2.{Pipe, Stream}
 
-import cats.syntax.all._
-
 import cats.effect.kernel.{Async, Resource, Sync}
 
 import retry.{RetryDetails, RetryPolicies}

--- a/sinks/src/main/scala/com.snowplowanalytics.snowplow.eventgen/sinks/Sink.scala
+++ b/sinks/src/main/scala/com.snowplowanalytics.snowplow.eventgen/sinks/Sink.scala
@@ -15,6 +15,7 @@ package com.snowplowanalytics.snowplow.eventgen.sinks
 import cats.effect.Async
 
 import fs2.Pipe
+import fs2.io.net.Network
 
 import com.snowplowanalytics.snowplow.eventgen.tracker.HttpRequest
 import com.snowplowanalytics.snowplow.eventgen.collector.CollectorPayload
@@ -27,7 +28,7 @@ trait Sink[F[_]] {
 }
 
 object Sink {
-  def make[F[_]: Async](sinkConfig: Config.Output): Sink[F] = sinkConfig match {
+  def make[F[_]: Async: Network](sinkConfig: Config.Output): Sink[F] = sinkConfig match {
     case fileConfig: Config.Output.File =>
       File.make(fileConfig)
     case httpConfig: Config.Output.Http =>


### PR DESCRIPTION
- Java 11 (AdoptOpenJDK) → Java 25 LTS (Eclipse Temurin)
- Scala 2.13.6 → 2.13.18, 2.12.14 → 2.12.21
- sbt 1.8.2 → 1.12.7 (required for Java 25 compatibility)
- Docker base image: adoptopenjdk:11-jre-hotspot-focal → eclipse-temurin:25-jre-noble
- Remove unused import in Kinesis.scala (stricter in new Scala version)