### PR TITLE
Fix non-deterministic event generation when seed is provided

### DIFF
--- a/config/config.example.hocon
+++ b/config/config.example.hocon
@@ -70,9 +70,10 @@
   # If not set, defaults to ["event-gen-1", "event-gen-2", ..., "event-gen-10"]
   # "appIds": ["my-app-1", "my-app-2", "my-app-3"]
 
-  # Optional. Seed to use to generate events
-  # For a same seed, the same event will get deterministically generated
-  # If not set, each event will get generated randomly
+  # Optional. Seed for deterministic event generation.
+  # When set, identical events are produced across runs (requires a fixed timestamp).
+  # Without a fixed timestamp, event structure and order will be the same across runs
+  # but timestamp-derived fields will differ.
   # "seed": 42
 
   "eventsPerPayload": {

--- a/core/src/main/scala/com/snowplowanalytics/snowplow/eventgen/enrich/SdkEvent.scala
+++ b/core/src/main/scala/com/snowplowanalytics/snowplow/eventgen/enrich/SdkEvent.scala
@@ -249,7 +249,7 @@ object SdkEvent {
   ): Gen[List[Event]] =
     for {
       cp <- CollectorPayload.gen(eventsPerPayload, time, frequencies, contexts, identitySource, duplicates, appIds)
-      enrichments <- if (generateEnrichments) Enrichments.gen.map(Some(_)) else Gen.const(None)
+      enrichments <- if (generateEnrichments) Enrichments.gen(time).map(Some(_)) else Gen.const(None)
       eid         <- Gen.uuid
     } yield eventsFromColPayload(cp, eid, enrichments)
 

--- a/core/src/main/scala/com/snowplowanalytics/snowplow/eventgen/primitives/package.scala
+++ b/core/src/main/scala/com/snowplowanalytics/snowplow/eventgen/primitives/package.scala
@@ -19,12 +19,9 @@ import java.nio.charset.Charset
 import java.time.Instant
 import java.util.{Base64, TimeZone}
 import scala.jdk.CollectionConverters._
-import scala.util.Random
 
 package object primitives {
   private val base64Encoder = Base64.getUrlEncoder.withoutPadding
-
-  private lazy val rng = new Random(30000L)
 
   type Epoch = Int
 
@@ -42,7 +39,7 @@ package object primitives {
 
   def genLocaleStrOpt: Gen[Option[String]] = Gen.option(genLocaleStr)
 
-  def genWords: Gen[String] = Gen.chooseNum(1, 10).map(n => rng.shuffle(LoremIpsum.take(n)).mkString(" ").capitalize)
+  def genWords: Gen[String] = Gen.chooseNum(1, 10).flatMap(n => Gen.pick(n, LoremIpsum).map(_.mkString(" ").capitalize))
 
   def genWordsOpt: Gen[Option[String]] = Gen.option(genWords)
 

--- a/core/src/main/scala/com/snowplowanalytics/snowplow/eventgen/protocol/Body.scala
+++ b/core/src/main/scala/com/snowplowanalytics/snowplow/eventgen/protocol/Body.scala
@@ -57,10 +57,7 @@ final case class Body(
 
 object Body {
 
-  private val DuplicationSeed      = 20000L
   private val ProbabilityPrecision = 10000
-
-  lazy val dupRng = new Random(DuplicationSeed)
 
   def gen(
     time: Instant,
@@ -85,10 +82,14 @@ object Body {
     baseGen.withPerturb { in =>
       if (duplicates.natProb == 0f | duplicates.natTotal == 0)
         in
-      else if (dupRng.nextInt(ProbabilityPrecision) < (duplicates.natProb * ProbabilityPrecision))
-        Seed(dupRng.nextInt(duplicates.natTotal).toLong)
-      else
-        in
+      else {
+        val (seedVal, _) = in.long
+        val rng          = new Random(seedVal)
+        if (rng.nextInt(ProbabilityPrecision) < (duplicates.natProb * ProbabilityPrecision))
+          Seed(rng.nextInt(duplicates.natTotal).toLong)
+        else
+          in
+      }
     }
 
   private def genWithEt(

--- a/core/src/main/scala/com/snowplowanalytics/snowplow/eventgen/protocol/common/EventTransaction.scala
+++ b/core/src/main/scala/com/snowplowanalytics/snowplow/eventgen/protocol/common/EventTransaction.scala
@@ -35,22 +35,22 @@ final case class EventTransaction(
 
 object EventTransaction {
 
-  lazy val etRng = new Random(10000L)
-
   def genDup(synProb: Float, synTotal: Int): Gen[EventTransaction] =
     (
       genIntOpt,
       Gen.option(
-        Gen
-          .uuid
-          .withPerturb(in =>
-            if (synProb == 0 | synTotal == 0)
-              in
-            else if (etRng.nextInt(10000) < (synProb * 10000))
-              Seed(etRng.nextInt(synTotal).toLong)
+        Gen.uuid.withPerturb { in =>
+          if (synProb == 0 | synTotal == 0)
+            in
+          else {
+            val (seedVal, _) = in.long
+            val rng          = new Random(seedVal)
+            if (rng.nextInt(10000) < (synProb * 10000))
+              Seed(rng.nextInt(synTotal).toLong)
             else
               in
-          )
+          }
+        }
       )
     ).mapN(EventTransaction.apply)
 

--- a/core/src/main/scala/com/snowplowanalytics/snowplow/eventgen/protocol/enrichment/CrossDomainEnrichment.scala
+++ b/core/src/main/scala/com/snowplowanalytics/snowplow/eventgen/protocol/enrichment/CrossDomainEnrichment.scala
@@ -24,9 +24,9 @@ case class CrossDomainEnrichment(
 )
 
 object CrossDomainEnrichment {
-  def gen: Gen[CrossDomainEnrichment] =
+  def gen(now: Instant): Gen[CrossDomainEnrichment] =
     (
       genStringOpt("refr_domain_userid", 10),
-      genInstantOpt(Instant.now)
+      genInstantOpt(now)
     ).mapN(CrossDomainEnrichment.apply)
 }

--- a/core/src/main/scala/com/snowplowanalytics/snowplow/eventgen/protocol/enrichment/DefaultEnrichment.scala
+++ b/core/src/main/scala/com/snowplowanalytics/snowplow/eventgen/protocol/enrichment/DefaultEnrichment.scala
@@ -24,9 +24,9 @@ case class DefaultEnrichment(
 )
 
 object DefaultEnrichment {
-  def gen: Gen[DefaultEnrichment] =
+  def gen(now: Instant): Gen[DefaultEnrichment] =
     (
-      genInstant(Instant.now),
-      genInstant(Instant.now)
+      genInstant(now),
+      genInstant(now)
     ).mapN(DefaultEnrichment.apply)
 }

--- a/core/src/main/scala/com/snowplowanalytics/snowplow/eventgen/protocol/enrichment/Enrichments.scala
+++ b/core/src/main/scala/com/snowplowanalytics/snowplow/eventgen/protocol/enrichment/Enrichments.scala
@@ -12,6 +12,7 @@
  */
 package com.snowplowanalytics.snowplow.eventgen.protocol.enrichment
 
+import java.time.Instant
 import cats.implicits._
 import org.scalacheck.Gen
 import org.scalacheck.cats.implicits._
@@ -30,15 +31,15 @@ final case class Enrichments(
 
 object Enrichments {
 
-  def gen: Gen[Enrichments] =
+  def gen(now: Instant): Gen[Enrichments] =
     (
-      DefaultEnrichment.gen,
+      DefaultEnrichment.gen(now),
       Gen.option(IpEnrichment.gen),
       Gen.option(UrlEnrichment.gen),
       Gen.option(RefererEnrichment.gen),
       Gen.option(CampaignAttributionEnrichment.gen),
       Gen.option(CurrencyConversionEnrichment.gen),
-      Gen.option(CrossDomainEnrichment.gen),
+      Gen.option(CrossDomainEnrichment.gen(now)),
       Gen.option(EventFingerprintEnrichment.gen),
       Gen.option(DeprecatedFields.gen)
     ).mapN(Enrichments.apply)

--- a/sinks/src/main/scala/com.snowplowanalytics.snowplow.eventgen/Main.scala
+++ b/sinks/src/main/scala/com.snowplowanalytics.snowplow.eventgen/Main.scala
@@ -92,7 +92,7 @@ object Main extends IOApp {
       .compile
       .drain
 
-  private def mkStream[F[_]: Async, A](config: Config, mkGen: Instant => ScalaGen[A]): Stream[F, A] =
+  private[eventgen] def mkStream[F[_]: Async, A](config: Config, mkGen: Instant => ScalaGen[A]): Stream[F, A] =
     for {
       rng <- Stream.emit {
         config.seed.fold(new scala.util.Random(scala.util.Random.nextInt()))(seed => new scala.util.Random(seed))
@@ -113,10 +113,19 @@ object Main extends IOApp {
             Stream.evalSeq(List.fill(batchSize)(runGen(mkGen(time), rng)).pure[F])
           }
         case None =>
-          Stream(1)
-            .repeat
-            .covary[F]
-            .parEvalMap(Runtime.getRuntime.availableProcessors * 5)(_ => Sync[F].delay(runGen(mkGen(time), rng)))
+          config.seed match {
+            case Some(seed) =>
+              Stream.eval(Sync[F].delay(println(s"Deterministic mode: seed=$seed, generating events sequentially"))) >>
+                Stream.repeatEval(Sync[F].delay(runGen(mkGen(time), rng)))
+            case None =>
+              Stream.eval(
+                Sync[F].delay(println("Non-deterministic mode: no seed provided, generating events in parallel"))
+              ) >>
+                Stream(1)
+                  .repeat
+                  .covary[F]
+                  .parEvalMap(Runtime.getRuntime.availableProcessors * 5)(_ => Sync[F].delay(runGen(mkGen(time), rng)))
+          }
       }
       event <- config.eventsTotal.fold(events)(events.take)
     } yield event

--- a/sinks/src/test/scala/com/snowplowanalytics/snowplow/eventgen/DeterminismSpec.scala
+++ b/sinks/src/test/scala/com/snowplowanalytics/snowplow/eventgen/DeterminismSpec.scala
@@ -1,0 +1,171 @@
+/*
+ * Copyright (c) 2021-2025 Snowplow Analytics Ltd. All rights reserved.
+ *
+ * This program is licensed to you under the Apache License Version 2.0,
+ * and you may not use this file except in compliance with the Apache License Version 2.0.
+ * You may obtain a copy of the Apache License Version 2.0 at http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the Apache License Version 2.0 is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
+ */
+package com.snowplowanalytics.snowplow.eventgen
+
+import java.time.Instant
+
+import fs2.Stream
+
+import cats.effect.IO
+import cats.effect.unsafe.implicits.global
+
+import org.specs2.mutable.Specification
+
+class DeterminismSpec extends Specification {
+  sequential
+
+  private val fixedTimestamp = Instant.parse("2026-01-01T00:00:00Z")
+  private val eventCount     = 50
+
+  private def mkConfig(seed: Option[Long], events: GenConfig.Events): Config =
+    Config(
+      events = events,
+      output = Config.Output.Stdout,
+      eventsTotal = Some(eventCount.toLong),
+      timestamp = Config.Timestamp.Fixed(fixedTimestamp),
+      appIds = List("test-app"),
+      seed = seed,
+      eventsPerPayload = GenConfig.EventsPerPayload(1, 1),
+      eventsFrequencies = GenConfig.EventsFrequencies(1, 1, 1, 1, 0, 0, 1, Map.empty),
+      contextsPerEvent = GenConfig.ContextsPerEvent(0, 3),
+      duplicates = None,
+      rate = None,
+      userGraph = None,
+      appProfiles = None
+    )
+
+  private def collectCollectorPayloads(config: Config): List[List[Byte]] =
+    Main
+      .mkStream[IO, collector.CollectorPayload](config, Gen.collectorPayload(config, _))
+      .map(_.toRaw.toList)
+      .compile
+      .toList
+      .unsafeRunSync()
+
+  private def collectEnriched(config: Config): List[String] = {
+    val enriched = config.events.asInstanceOf[GenConfig.Events.Enriched]
+    Main
+      .mkStream[IO, List[String]](config, Gen.enriched(config, _, enriched.format, enriched.generateEnrichments))
+      .flatMap(Stream.emits)
+      .compile
+      .toList
+      .unsafeRunSync()
+  }
+
+  private def collectHttp(config: Config): List[String] = {
+    val http = config.events.asInstanceOf[GenConfig.Events.Http]
+    Main
+      .mkStream[IO, tracker.HttpRequest](config, Gen.httpRequest(config, _, http.methodFrequencies))
+      .map(_.toString)
+      .compile
+      .toList
+      .unsafeRunSync()
+  }
+
+  "CollectorPayloads determinism" should {
+
+    "produce identical events across two seeded runs" in {
+      val config = mkConfig(seed = Some(12345L), GenConfig.Events.CollectorPayloads)
+      val run1   = collectCollectorPayloads(config)
+      val run2   = collectCollectorPayloads(config)
+
+      run1.size must_== eventCount
+      run1 must_== run2
+    }
+
+    "produce different events with different seeds" in {
+      val run1 = collectCollectorPayloads(mkConfig(seed = Some(12345L), GenConfig.Events.CollectorPayloads))
+      val run2 = collectCollectorPayloads(mkConfig(seed = Some(99999L), GenConfig.Events.CollectorPayloads))
+
+      run1.size must_== eventCount
+      run2.size must_== eventCount
+      run1 must_!= run2
+    }
+
+    "produce different events without seed" in {
+      val config = mkConfig(seed = None, GenConfig.Events.CollectorPayloads)
+      val run1   = collectCollectorPayloads(config)
+      val run2   = collectCollectorPayloads(config)
+
+      run1.size must_== eventCount
+      run2.size must_== eventCount
+      run1 must_!= run2
+    }
+  }
+
+  "Enriched events determinism" should {
+
+    val enrichedTsv = GenConfig.Events.Enriched(GenConfig.Events.Enriched.Format.TSV, generateEnrichments = false)
+
+    "produce identical events across two seeded runs" in {
+      val config = mkConfig(seed = Some(12345L), enrichedTsv)
+      val run1   = collectEnriched(config)
+      val run2   = collectEnriched(config)
+
+      run1.size must beGreaterThan(0)
+      run1 must_== run2
+    }
+
+    "produce different events with different seeds" in {
+      val run1 = collectEnriched(mkConfig(seed = Some(12345L), enrichedTsv))
+      val run2 = collectEnriched(mkConfig(seed = Some(99999L), enrichedTsv))
+
+      run1.size must beGreaterThan(0)
+      run2.size must beGreaterThan(0)
+      run1 must_!= run2
+    }
+
+    "produce different events without seed" in {
+      val config = mkConfig(seed = None, enrichedTsv)
+      val run1   = collectEnriched(config)
+      val run2   = collectEnriched(config)
+
+      run1.size must beGreaterThan(0)
+      run2.size must beGreaterThan(0)
+      run1 must_!= run2
+    }
+  }
+
+  "HTTP requests determinism" should {
+
+    val http = GenConfig.Events.Http(methodFrequencies = None)
+
+    "produce identical events across two seeded runs" in {
+      val config = mkConfig(seed = Some(12345L), http)
+      val run1   = collectHttp(config)
+      val run2   = collectHttp(config)
+
+      run1.size must_== eventCount
+      run1 must_== run2
+    }
+
+    "produce different events with different seeds" in {
+      val run1 = collectHttp(mkConfig(seed = Some(12345L), http))
+      val run2 = collectHttp(mkConfig(seed = Some(99999L), http))
+
+      run1.size must_== eventCount
+      run2.size must_== eventCount
+      run1 must_!= run2
+    }
+
+    "produce different events without seed" in {
+      val config = mkConfig(seed = None, http)
+      val run1   = collectHttp(config)
+      val run2   = collectHttp(config)
+
+      run1.size must_== eventCount
+      run2.size must_== eventCount
+      run1 must_!= run2
+    }
+  }
+}


### PR DESCRIPTION
event generator, like random number generators with a [seed](https://en.wikipedia.org/wiki/Random_seed), is supposed to generate the same events in the same order when the same seed is provided across runs, as documented in the reference conf:

https://github.com/snowplow-incubator/snowplow-event-generator/blob/65f59617a96bb386fc3165e4218e5898946b0166/config/config.example.hocon#L74


This determinism ensures that generated events and their order aren't variables in controlled tests.


- Use sequential Stream.repeatEval instead of parallel parEvalMap when seed is set, so thread interleaving cannot reorder RNG calls
- Replace shared mutable Random instances (rng, dupRng, etRng) with seed-derived values from scalacheck's Seed
- Thread timestamp through enrichment generators instead of using Instant.now, so enrichment fields are also reproducible
- Add determinism tests for CollectorPayloads, Enriched, and HTTP