### PR TITLE
Avoid worker starvation

### DIFF
--- a/sinks/src/main/scala/com.snowplowanalytics.snowplow.eventgen/Main.scala
+++ b/sinks/src/main/scala/com.snowplowanalytics.snowplow.eventgen/Main.scala
@@ -109,9 +109,18 @@ object Main extends IOApp {
         case Some(rate) =>
           val tick      = rate.tickMillis.millis
           val batchSize = rate.eventsPerSecond * rate.tickMillis / 1000
-          Stream.awakeEvery[F](tick).flatMap { _ =>
-            Stream.evalSeq(List.fill(batchSize)(runGen(mkGen(time), rng)).pure[F])
+          val batch = config.seed match {
+            case Some(_) =>
+              Stream.range(0, batchSize).covary[F].evalMap(_ => Sync[F].delay(runGen(mkGen(time), rng)))
+            case None =>
+              Stream
+                .range(0, batchSize)
+                .covary[F]
+                .parEvalMapUnordered(Runtime.getRuntime.availableProcessors)(_ =>
+                  Sync[F].delay(runGen(mkGen(time), rng))
+                )
           }
+          Stream.awakeEvery[F](tick).flatMap(_ => batch)
         case None =>
           config.seed match {
             case Some(seed) =>
@@ -124,7 +133,9 @@ object Main extends IOApp {
                 Stream(1)
                   .repeat
                   .covary[F]
-                  .parEvalMap(Runtime.getRuntime.availableProcessors * 5)(_ => Sync[F].delay(runGen(mkGen(time), rng)))
+                  .parEvalMapUnordered(Runtime.getRuntime.availableProcessors)(_ =>
+                    Sync[F].delay(runGen(mkGen(time), rng))
+                  )
           }
       }
       event <- config.eventsTotal.fold(events)(events.take)

--- a/sinks/src/test/scala/com/snowplowanalytics/snowplow/eventgen/DeterminismSpec.scala
+++ b/sinks/src/test/scala/com/snowplowanalytics/snowplow/eventgen/DeterminismSpec.scala
@@ -27,7 +27,11 @@ class DeterminismSpec extends Specification {
   private val fixedTimestamp = Instant.parse("2026-01-01T00:00:00Z")
   private val eventCount     = 50
 
-  private def mkConfig(seed: Option[Long], events: GenConfig.Events): Config =
+  private def mkConfig(
+    seed: Option[Long],
+    events: GenConfig.Events,
+    rate: Option[GenConfig.Rate] = None
+  ): Config =
     Config(
       events = events,
       output = Config.Output.Stdout,
@@ -39,7 +43,7 @@ class DeterminismSpec extends Specification {
       eventsFrequencies = GenConfig.EventsFrequencies(1, 1, 1, 1, 0, 0, 1, Map.empty),
       contextsPerEvent = GenConfig.ContextsPerEvent(0, 3),
       duplicates = None,
-      rate = None,
+      rate = rate,
       userGraph = None,
       appProfiles = None
     )
@@ -100,6 +104,26 @@ class DeterminismSpec extends Specification {
       run1.size must_== eventCount
       run2.size must_== eventCount
       run1 must_!= run2
+    }
+
+    // Rate mode generates each tick's batch through a seed-aware path (sequential when seeded,
+    // parallel otherwise); these guard that the seeded path stays reproducible and the parallel
+    // path still yields the requested number of events.
+    "produce identical events across two seeded runs in rate mode" in {
+      val config =
+        mkConfig(seed = Some(12345L), GenConfig.Events.CollectorPayloads, rate = Some(GenConfig.Rate(1000, 100)))
+      val run1 = collectCollectorPayloads(config)
+      val run2 = collectCollectorPayloads(config)
+
+      run1.size must_== eventCount
+      run1 must_== run2
+    }
+
+    "produce the requested number of events without seed in rate mode" in {
+      val config = mkConfig(seed = None, GenConfig.Events.CollectorPayloads, rate = Some(GenConfig.Rate(1000, 100)))
+      val run1   = collectCollectorPayloads(config)
+
+      run1.size must_== eventCount
     }
   }
 


### PR DESCRIPTION
### Problem

In rate mode, each tick's batch was generated in a single synchronous `List.fill(batchSize)(runGen(...)).pure[F]` block. Event generation is CPU-bound, so one worker thread was monopolised for the whole batch, tripping cats-effect's starvation checker:

```
[WARNING] Your app's responsiveness to a new asynchronous event ... was in excess of 100 milliseconds. Your CPU is probably starving.
```

Beyond the log noise, it means the generator can't cleanly hold its target rate — if a batch takes longer than `tickMillis` to synthesise, ticks queue and the achieved rate drops below and varies around the configured `eventsPerSecond`.

### Fix

Generate each tick's batch one event at a time so the runtime can cede between events, applying the **same seed handling the no-rate branch already has**:

- **seeded** → sequential, single-RNG consumption in order → output stays reproducible;
- **unseeded** → parallelised across cores.

### Unordered parallel generation

Non-deterministic generation has no ordering contract, so both the rate and no-rate parallel paths now use `parEvalMapUnordered` instead of the order-preserving `parEvalMap` — the latter head-of-line blocks and buffers completed events to restore input order, for no benefit here. Parallelism is set to `availableProcessors` on both paths (generation is CPU-bound, so more in-flight fibers than cores buys no throughput); this replaces the no-rate path's previous `availableProcessors * 5`.

The no-rate path did not have the starvation itself (it already generated per-event), but is changed here for consistency so both parallel paths share one strategy.

### Determinism

Preserved by construction: the seeded paths consume the single `Random` in the identical order, so seeded output is byte-for-byte unchanged. `DeterminismSpec` previously covered only `rate=None`; this adds rate-mode cases so the seeded path's reproducibility and the parallel path's event count are protected. 11/11 pass.